### PR TITLE
Adding detail about bioc-bot not triggered if git merge

### DIFF
--- a/soumission_bioc.md
+++ b/soumission_bioc.md
@@ -133,6 +133,11 @@ BUILD, vous devez incrémenter le 'z' de votre numéro de version et poussez la
 modification. Seuls les push où le numéro de version est incrémenté relance le
 BUILD de Bioconductor.
 
+**Note :** si vous avez créé une branche pour faire vos correctifs et que vous mergez
+cette branche dans le master pour ensuite pousser les modifications, ne faites pas 
+l'incrémentation de version dans la branche mais bien une fois dans le master. Il 
+semble que le bioc-boc ne soit pas déclenché sinon.
+
 Une fois que le paquets passera l'étape de BUILD, votre reviewer vous fera ses
 demandes et commentaires. Vous devrez y répondre avant de pouvoir soumettre
 votre paquet. Même si les NOTES de BiocCheck n'empêchent pas un paquet d'être 


### PR DESCRIPTION
Il semble que le bot de bioconductor ne se déclenche pas si l'incrémentation de version est fait dans une branche qui est ensuite mergée. Il faut donc le faire dans le master après avoir mergé les modifications.